### PR TITLE
Add back sshd (temp), reduce verbosity

### DIFF
--- a/pkg/sshd/ssh.go
+++ b/pkg/sshd/ssh.go
@@ -52,6 +52,10 @@ type Server struct {
 	forwardHandler *ForwardedTCPHandler
 }
 
+func init() {
+	inprocessInit = InitFromSecret
+}
+
 // InitFromSecret is a helper method to init the sshd using a secret or CA address
 func InitFromSecret(sshCM map[string][]byte, ns string) {
 


### PR DESCRIPTION
Current plan is to have sshd as an optional external component that is configured and started, but not linked in.