### PR TITLE
Metrics fix, identify container as 'cloudrun'

### DIFF
--- a/pkg/mesh/krun.go
+++ b/pkg/mesh/krun.go
@@ -67,6 +67,9 @@ type KRun struct {
 	// TODO: use service name as default
 	Name string
 
+	// Revision
+	Rev string
+
 	// If not empty, will run Istio-agent as a gateway (router instead of sidecar)
 	// with the "istio: $Gateway" label.
 	Gateway string


### PR DESCRIPTION
Also use K_REVISION as version, more consistency with k8s.