### PR TITLE
Replace network with scope for traffic director.

### DIFF
--- a/cmd/krun/krun.go
+++ b/cmd/krun/krun.go
@@ -168,7 +168,7 @@ func initPorts(kr *mesh.KRun, hb *hbone.HBone) {
 
 func startTd(kr *mesh.KRun) {
 	kr.InitForTD()
-	log.Printf("Preparing to connect to TD mesh with project number: %s and network name: %s", kr.ProjectNumber, kr.NetworkName)
+	log.Printf("Preparing to connect to TD mesh with project number: %s and scope : %s", kr.ProjectNumber, kr.TdSidecarEnv.Scope)
 
 	if os.Getuid() != 0 {
 		log.Fatal("td only supports running as root")

--- a/pkg/mesh/krun.go
+++ b/pkg/mesh/krun.go
@@ -216,10 +216,6 @@ func New() *KRun {
 }
 
 func (kr *KRun) InitForTD() {
-	if len(kr.NetworkName) == 0 {
-		kr.NetworkName = "default"
-	}
-
 	if len(kr.ProjectNumber) == 0 {
 		if projectNumber, err := kr.TdSidecarEnv.fetchProjectNumber(); err != nil {
 			log.Println("Unable to auto-generate project_number: ", err)
@@ -247,8 +243,8 @@ func (kr *KRun) InitForTD() {
 // Traffic Director expects MESH env in the following formats:
 // * td:
 // * td:projects={PROJECT_NUMBER}
-// * td:networks={NETWORK_NAME}
-// * td:projects={PROJECT_NUMBER}&networks={NETWORK_NAME}
+// * td:scopes={SCOPE_NAME}
+// * td:projects={PROJECT_NUMBER}&scopes={SCOPE_NAME}
 
 func (kr *KRun) InitForTDFromMeshEnv() bool {
 	mesh := os.Getenv("MESH")
@@ -266,8 +262,8 @@ func (kr *KRun) InitForTDFromMeshEnv() bool {
 			kr.ProjectNumber = projectNumber
 		}
 
-		if networkName := values.Get("networks"); len(networkName) > 0 {
-			kr.NetworkName = networkName
+		if scope := values.Get("scopes"); len(scope) > 0 {
+			kr.TdSidecarEnv.Scope = scope
 		}
 	}
 	return true

--- a/pkg/mesh/td.go
+++ b/pkg/mesh/td.go
@@ -29,6 +29,8 @@ import (
 // TDSidecarEnv contains environment files that controls how an envoy proxy will be
 // set up and interact with Traffic Director control plane.
 type TdSidecarEnv struct {
+	// Scope specifies the mesh in a project.
+	Scope string
 	// List of comma seperated IP ranges that will have their traffic intercepted
 	// and redirected to Envoy. Set it to '*' to intercept all traffic.
 	ServiceCidr string
@@ -59,6 +61,7 @@ type TdSidecarEnv struct {
 // NewTdSidecarEnv sets up TdSideCarEnv with defaults.
 func NewTdSidecarEnv() *TdSidecarEnv {
 	return &TdSidecarEnv{
+		Scope:            "default",
 		ServiceCidr:      "*",
 		EnvoyPort:        "15001",
 		EnvoyAdminPort:   "15000",
@@ -125,7 +128,7 @@ func (kr *KRun) prepareTrafficDirectorBootstrap(templatePath string, outputPath 
 	template := string(data)
 	template = strings.ReplaceAll(template, "ENVOY_NODE_ID", kr.TdSidecarEnv.NodeID)
 	template = strings.ReplaceAll(template, "ENVOY_ZONE", kr.TdSidecarEnv.EnvoyZone)
-	template = strings.ReplaceAll(template, "VPC_NETWORK_NAME", kr.NetworkName)
+	template = strings.ReplaceAll(template, "VPC_NETWORK_NAME", fmt.Sprintf("scope:%s", kr.TdSidecarEnv.Scope))
 	template = strings.ReplaceAll(template, "CONFIG_PROJECT_NUMBER", kr.ProjectNumber)
 	template = strings.ReplaceAll(template, "ENVOY_PORT", kr.TdSidecarEnv.EnvoyPort)
 	template = strings.ReplaceAll(template, "ENVOY_ADMIN_PORT", kr.TdSidecarEnv.EnvoyAdminPort)


### PR DESCRIPTION
Fixes #23

When cloud run application joins a traffic director mesh, it will be identified by (projectNumber, scopeName) rather than (projectNumber, networkName).

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR