### PR TITLE
Make DNS Interception disableable for Traffic Director configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ gcloud alpha run deploy ${CLOUDRUN_SERVICE} \
           --port 15009 \
           --image ${IMAGE} \
           --vpc-connector projects/${CONFIG_PROJECT_ID}/locations/${REGION}/connectors/serverlesscon \
-         --set-env-vars="MESH=//container.googleapis.com/projects/${CONFIG_PROJECT_ID}/locations/${CLUSTER_LOCATION}/clusters/${CLUSTER_NAME}" 
+          --set-env-vars="MESH=//container.googleapis.com/projects/${CONFIG_PROJECT_ID}/locations/${CLUSTER_LOCATION}/clusters/${CLUSTER_NAME}" 
 ```
 
 For versions of `gcloud` older than 353.0, replace `--execution-environment=gen2` with `--sandbox=minivm`.
@@ -267,6 +267,12 @@ You can also use MESH=gke://${CONFIG_PROJECT_ID}, allowing the workload to autom
 - `--service-account` is recommended for 'minimal privilege'. The service account will act as a K8s SA, and have its
   RBAC permissions
 - `--use-http2`  and `--port 15009` are required
+
+If you want to use the golden-image without DNS interception, you can disable it using:
+```shell
+          --set-env-vars="DISABLE_DNS_INTERCEPTION=true" 
+```
+this will disable the redirect of DNS requests to Envoy via IPTables.
 
 ### Configure the CloudRun service in K8s
 

--- a/pkg/mesh/td.go
+++ b/pkg/mesh/td.go
@@ -115,7 +115,7 @@ func (td *TdSidecarEnv) getIPTablesInterceptionEnvVars() []string {
 		"TRAFFIC_DIRECTOR_GCE_VM_DEPLOYMENT_OVERRIDE=true",
 		"DISABLE_REDIRECTION_ON_LOCAL_LOOPBACK=true",
 	}
-	if !strings.EqualFold(os.Env("DISABLE_DNS_INTERCEPTION"),"true") {
+	if !strings.EqualFold(os.Getenv("DISABLE_DNS_INTERCEPTION"),"true") {
 		envs = append(envs, 
 			fmt.Sprintf("%s=%s", "ENVOY_DNS_PORT", td.EnvoyDnsPort),
 		)

--- a/pkg/mesh/td.go
+++ b/pkg/mesh/td.go
@@ -114,8 +114,13 @@ func (td *TdSidecarEnv) getIPTablesInterceptionEnvVars() []string {
 	envs := []string{
 		"TRAFFIC_DIRECTOR_GCE_VM_DEPLOYMENT_OVERRIDE=true",
 		"DISABLE_REDIRECTION_ON_LOCAL_LOOPBACK=true",
-		fmt.Sprintf("%s=%s", "ENVOY_DNS_PORT", td.EnvoyDnsPort),
 	}
+	if !strings.EqualFold(os.Env("DISABLE_DNS_INTERCEPTION"),"true") {
+		envs = append(envs, 
+			fmt.Sprintf("%s=%s", "ENVOY_DNS_PORT", td.EnvoyDnsPort),
+		)
+	}
+
 	return envs
 }
 


### PR DESCRIPTION
Without issue generated before hand. At the moment, when using krun with TD, an IPTables entry is generated to redirect packets to UDP port 53 to port 15053. TD only registers a UDP Listener on this port, if the backend is configured using a Serverless NEG. Having the ability to disable this, would make the golden-image also more usable with other types of backends.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR